### PR TITLE
Fixes getPin

### DIFF
--- a/src/main/java/org/powerbot/script/ClientContext.java
+++ b/src/main/java/org/powerbot/script/ClientContext.java
@@ -163,6 +163,6 @@ public abstract class ClientContext<C extends Client> {
 	 * @return the PIN or {@code null} if unspecified
 	 */
 	public String getPin() {
-		return properties.getProperty("account." + properties.getProperty("login.user") + ".pin");
+		return properties.getProperty("login." + properties.getProperty("login.user") + ".pin");
 	}
 }


### PR DESCRIPTION
The method getPin was returning null as the property requested didn't exist. account.<user_id>.pin was changed to login.<user_id>.pin in one of the PRs. Artifact with bugfix was tested by creator of #2084 .