### PR TITLE
temporary workaround for deformed cache NPCs

### DIFF
--- a/src/main/java/org/powerbot/bot/cache/JagexStream.java
+++ b/src/main/java/org/powerbot/bot/cache/JagexStream.java
@@ -65,7 +65,7 @@ public class JagexStream {
 		offset = loc;
 	}
 
-	private int getLeft() {
+	public int getLeft() {
 		return getLength() - getLocation();
 	}
 

--- a/src/main/java/org/powerbot/script/rt4/CacheNpcConfig.java
+++ b/src/main/java/org/powerbot/script/rt4/CacheNpcConfig.java
@@ -200,6 +200,7 @@ public class CacheNpcConfig {
 				}
 				break;
 			}
+			if(stream.getLeft() == 0) break;
 		}
 	}
 }


### PR DESCRIPTION
This a temporary patch for deformed cache payloads for Npcs. Affected entities will have a string literal "null" as their name, but IDs work fine. Note that the vast majority of Npcs are not affected by this.