### PR TITLE
Fix withdraw x

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -253,7 +253,7 @@ public class Bank extends ItemQuery<Item> {
 			}) || item.interact(action))) {
 				return false;
 			}
-		} else if (!item.interact(action)) {
+		} else if (!item.interact(command -> command.action.equalsIgnoreCase(action))) {
 			return false;
 		}
 		if (action.endsWith("X")) {

--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -245,12 +245,7 @@ public class Bank extends ItemQuery<Item> {
 			ctx.bank.currentTab(0);
 		}
 		if (item.contains(ctx.input.getLocation())) {
-			if (!(ctx.menu.click(new Filter<MenuCommand>() {
-				@Override
-				public boolean accept(final MenuCommand command) {
-					return command.action.equalsIgnoreCase(action);
-				}
-			}) || item.interact(action))) {
+			if (!(ctx.menu.click(command -> command.action.equalsIgnoreCase(action)) || item.interact(action))) {
 				return false;
 			}
 		} else if (!item.interact(command -> command.action.equalsIgnoreCase(action))) {


### PR DESCRIPTION
The default implementation of `interact` uses a Filter that checks for string contains rather than equals. 
This is an issue if the user's Withdraw-X quantity contains any of the preset values (1, 5, 10) since this will cause it to select the wrong withdraw amount.