### PR TITLE
Bank improvements

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -267,66 +267,7 @@ public class Bank extends ItemQuery<Item> {
 	 * @return {@code true} if the item was withdrawn, does not determine if amount was matched; otherwise, {@code false}
 	 */
 	public boolean withdraw(final Item item, final int amount) {
-		if (!opened() || !item.valid() || amount < Amount.X.getValue()) {
-			return false;
-		}
-
-		if (!ctx.widgets.scroll(
-				item.component,
-				ctx.widgets.widget(Constants.BANK_WIDGET).component(Constants.BANK_ITEMS),
-				ctx.widgets.widget(Constants.BANK_WIDGET).component(Constants.BANK_SCROLLBAR),
-				true
-		)) {
-			return false;
-		}
-		final int count = select().id(item.id()).count(true);
-		final String action;
-		if (count == 1 || amount == 1) {
-			action = "Withdraw-1";
-		} else if (amount == 0 || count <= amount) {
-			action = "Withdraw-All";
-		} else if (amount == 5 || amount == 10) {
-			action = "Withdraw-" + amount;
-		} else if (amount == -1) {
-			action = "Withdraw-All-but-1";
-		} else if (amount == -2) {
-			action = "Placeholder";
-		} else if (amount == -3) {
-			action = "Withdraw-" + withdrawXAmount();
-		} else if (check(item, amount)) {
-			action = "Withdraw-" + amount;
-		} else {
-			action = "Withdraw-X";
-		}
-		final int cache = ctx.inventory.select().count(true);
-		if (!item.component().visible()) {
-			ctx.bank.currentTab(0);
-		}
-		if (item.contains(ctx.input.getLocation())) {
-			if (!(ctx.menu.click(command -> command.action.equalsIgnoreCase(action)) || item.interact(action))) {
-				return false;
-			}
-		} else if (!item.interact(command -> command.action.equalsIgnoreCase(action))) {
-			return false;
-		}
-		if (action.endsWith("X")) {
-			if (!Condition.wait(new Condition.Check() {
-				@Override
-				public boolean poll() {
-					return ctx.widgets.widget(Constants.CHAT_INPUT).component(Constants.CHAT_INPUT_TEXT).visible();
-				}
-			})) {
-				return false;
-			}
-			Condition.sleep();
-			ctx.input.sendln(amount + "");
-		}
-		return Condition.wait(new Condition.Check() {
-			@Override
-			public boolean poll() {
-				return cache != ctx.inventory.select().count(true);
-			}
-		});
+		return withdrawAmount(item, amount) > 0;
 	}
 
 	/**

--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -689,28 +689,6 @@ public class Bank extends ItemQuery<Item> {
 		return ctx.widgets.widget(Constants.BANK_WIDGET).component(Constants.BANK_DEPOSIT_EQUIPMENT).interact("Deposit");
 	}
 
-	private boolean check(final Item item, final int amt) {
-		item.hover();
-		Condition.wait(new Condition.Check() {
-			@Override
-			public boolean poll() {
-				return ctx.menu.indexOf(new Filter<MenuCommand>() {
-					@Override
-					public boolean accept(final MenuCommand command) {
-						return command.action.startsWith("Withdraw") || command.action.startsWith("Deposit");
-					}
-				}) != -1;
-			}
-		}, 20, 10);
-		final String s = "-".concat(Integer.toString(amt)) + " ";
-		for (final String a : ctx.menu.items()) {
-			if (a.contains(s)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	/**
 	 * Amount
 	 * An enumeration providing standard bank amount options.

--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -267,7 +267,7 @@ public class Bank extends ItemQuery<Item> {
 	 * @return {@code true} if the item was withdrawn, does not determine if amount was matched; otherwise, {@code false}
 	 */
 	public boolean withdraw(final Item item, final int amount) {
-		if (!opened() || !item.valid() || amount < -1) {
+		if (!opened() || !item.valid() || amount < Amount.X.getValue()) {
 			return false;
 		}
 

--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -213,6 +213,18 @@ public class Bank extends ItemQuery<Item> {
 	}
 
 	/**
+	 * Withdraws an item with the provided name and amount.
+	 * If multiple items match the filter, the first one is chosen.
+	 *
+	 * @param filter the filter to apply to the items in the bank
+	 * @param amount the amount to withdraw
+	 * @return {@code true} if the item was withdrawn, does not determine if amount was matched; otherwise, {@code false}
+	 */
+	public boolean withdraw(final Filter<Item> filter, final Amount amount) {
+		return withdraw(select().select(filter).poll(), amount.getValue());
+	}
+
+	/**
 	 * Withdraws an item with the provided id and amount.
 	 *
 	 * @param id     the id of the item
@@ -233,6 +245,18 @@ public class Bank extends ItemQuery<Item> {
 	 */
 	public boolean withdraw(final String name, final int amount) {
 		return withdraw(select().name(name).poll(), amount);
+	}
+
+	/**
+	 * Withdraws an item with the provided name and amount.
+	 * If multiple items match the filter, the first one is chosen.
+	 *
+	 * @param filter the filter to apply to the items in the bank
+	 * @param amount the amount to withdraw
+	 * @return {@code true} if the item was withdrawn, does not determine if amount was matched; otherwise, {@code false}
+	 */
+	public boolean withdraw(final Filter<Item> filter, final int amount) {
+		return withdraw(select().select(filter).poll(), amount);
 	}
 
 	/**

--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -201,6 +201,18 @@ public class Bank extends ItemQuery<Item> {
 	}
 
 	/**
+	 * Withdraws an item with the provided name and amount.
+	 * If multiple items of the same name are present, the first one is chosen.
+	 *
+	 * @param name   the name of the item
+	 * @param amount the amount to withdraw
+	 * @return {@code true} if the item was withdrawn, does not determine if amount was matched; otherwise, {@code false}
+	 */
+	public boolean withdraw(final String name, final Amount amount) {
+		return withdraw(select().name(name).poll(), amount.getValue());
+	}
+
+	/**
 	 * Withdraws an item with the provided id and amount.
 	 *
 	 * @param id     the id of the item
@@ -209,6 +221,18 @@ public class Bank extends ItemQuery<Item> {
 	 */
 	public boolean withdraw(final int id, final int amount) {
 		return withdraw(select().id(id).poll(), amount);
+	}
+
+	/**
+	 * Withdraws an item with the provided name and amount.
+	 * If multiple items of the same name are present, the first one is chosen.
+	 *
+	 * @param name   the name of the item
+	 * @param amount the amount to withdraw
+	 * @return {@code true} if the item was withdrawn, does not determine if amount was matched; otherwise, {@code false}
+	 */
+	public boolean withdraw(final String name, final int amount) {
+		return withdraw(select().name(name).poll(), amount);
 	}
 
 	/**

--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -5,6 +5,8 @@ import org.powerbot.script.*;
 
 import java.util.*;
 
+import static org.powerbot.script.rt4.Constants.*;
+
 /**
  * Bank
  * A utility class for withdrawing and depositing items, opening and closing the bank, and finding the closest usable bank.
@@ -167,17 +169,25 @@ public class Bank extends ItemQuery<Item> {
 	}
 
 	/**
-	 * @return {@code true} if the bank is not opened, or if it was successfully closed; otherwise {@code false}
+	 * Closes the bank
+	 * @param key if {@code true}, and escape closing enabled, will press escape key. If {@code false}, clicks the close button.
+	 * @return {@code true} if the bank is already closed or is successfully closed; {@code false} otherwise.
 	 */
-	public boolean close() {
-		return !opened() || (ctx.widgets.widget(Constants.BANK_WIDGET).component(Constants.BANK_MASTER).component(Constants.BANK_CLOSE).click(true) && Condition.wait(new Condition.Check() {
-			@Override
-			public boolean poll() {
-				return !opened();
-			}
-		}, 30, 10));
+	public boolean close(final boolean key) {
+		if (!opened()) {
+			return true;
+		}
+		final Component closeButton = ctx.widgets.component(BANK_WIDGET, BANK_MASTER, BANK_CLOSE);
+		return ((key && ctx.game.settings.escClosingEnabled() && ctx.input.send("{VK_ESCAPE}")) || closeButton.click())
+				&& Condition.wait(() -> !opened(), 30, 10);
 	}
 
+	/**
+	 * {@link #close(boolean)} with {@code false}
+	 */
+	public boolean close() {
+		return close(false);
+	}
 
 	/**
 	 * Withdraws an item with the provided id and amount.

--- a/src/main/java/org/powerbot/script/rt4/Game.java
+++ b/src/main/java/org/powerbot/script/rt4/Game.java
@@ -1,8 +1,10 @@
 package org.powerbot.script.rt4;
 
 import org.powerbot.bot.rt4.client.Client;
+import org.powerbot.script.Condition;
+import org.powerbot.script.Filter;
+import org.powerbot.script.MenuCommand;
 import org.powerbot.script.Tile;
-import org.powerbot.script.*;
 
 import java.applet.Applet;
 import java.awt.*;
@@ -15,6 +17,7 @@ public class Game extends ClientAccessor {
 	private static final int[] ARRAY_SIN = new int[2048];
 	private static final int[] ARRAY_COS = new int[2048];
 
+	public Settings settings;
 
 	static {
 		for (int i = 0; i < 2048; i++) {
@@ -25,6 +28,7 @@ public class Game extends ClientAccessor {
 
 	public Game(final ClientContext ctx) {
 		super(ctx);
+		this.settings = new Settings();
 	}
 
 	/**
@@ -515,6 +519,12 @@ public class Game extends ClientAccessor {
 				return "";
 			}
 			return value == 13 ? "{VK_ESCAPE}" : "{VK_F" + value + "}";
+		}
+	}
+
+	public class Settings {
+		public boolean escClosingEnabled() {
+			return ctx.varpbits.varpbit(1224, 31, 1) == 1;
 		}
 	}
 }

--- a/src/main/java/org/powerbot/script/rt4/Menu.java
+++ b/src/main/java/org/powerbot/script/rt4/Menu.java
@@ -92,6 +92,26 @@ public class Menu extends ClientAccessor implements Stoppable {
 	}
 
 	/**
+	 * Checks if the menu contains any MenuCommand matching the filter
+	 *
+	 * @param filter the filter to apply
+	 * @return true if a MenuCommand exists; false otherwise
+	 */
+	public boolean contains(final Filter<? super MenuCommand> filter) {
+		return indexOf(filter) != -1;
+	}
+
+	/**
+	 * Checks if the menu contains the specified action.
+	 *
+	 * @param action The action string to search for. This does a case insensitive contains.
+	 * @return true if the action exists. False otherwise.
+	 */
+	public boolean containsAction(final String action) {
+		return indexOf(c -> c.action.toLowerCase().contains(action.toLowerCase())) != -1;
+	}
+
+	/**
 	 * Attempts to hover over the menu command, given the provided filter.
 	 *
 	 * @param filter The filter to apply to the menu.


### PR DESCRIPTION
This makes a couple of changes to the Bank API to add additional useful methods and clean up some of the methods.
- Adds an overload to `close` to support closing by using the ESC key;
  - the default implementation was kept to use the close button
- Adds a helper method `game.settings.escClosingEnabled()` to check if the user has ESC interface closing enabled in their settings;
- Adds overloads to `withdraw` to support withdrawing by name and Filter;
- Adds `withdrawAmount` that withdraws items from the bank and returns the number the items withdrawn;
- Added a couple helper methods to get the withdraw logic down from 61 lines to 23 and to reduce some duplicate code between depositing and withdrawing;
- Refactored existing `withdraw` method to return `withdrawnAmount() > 0` to keep its current behavior;
- Added helper methods to Menu for checking if a `MenuCommand` and specific action exists to make bank code easier to read;