### PR TITLE
replace method reference with explicit lambda.

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/BasicQuery.java
+++ b/src/main/java/org/powerbot/script/rt4/BasicQuery.java
@@ -182,6 +182,7 @@ public abstract class BasicQuery<K extends Locatable & Identifiable & Nameable &
 	 */
 	@Override
 	public BasicQuery<K> viewable() {
-		return select(Viewable::inViewport);
+		//DO NOT REPLACE WITH METHOD REFERENCE
+		return select(k -> k.inViewport());
 	}
 }

--- a/src/main/java/org/powerbot/script/rt4/BasicQuery.java
+++ b/src/main/java/org/powerbot/script/rt4/BasicQuery.java
@@ -183,6 +183,7 @@ public abstract class BasicQuery<K extends Locatable & Identifiable & Nameable &
 	@Override
 	public BasicQuery<K> viewable() {
 		//DO NOT REPLACE WITH METHOD REFERENCE
+		//see #2119
 		return select(k -> k.inViewport());
 	}
 }


### PR DESCRIPTION
Method references and generics don't play well together. Replacing the lambda with a method reference causes an exception to be thrown since the type cannot be correctly inferred. 

Fixes #2119