### PR TITLE
Merge bug/2124-pvp-login-state to master

### DIFF
--- a/src/main/java/org/powerbot/bot/rt4/TLoginState.java
+++ b/src/main/java/org/powerbot/bot/rt4/TLoginState.java
@@ -1,0 +1,21 @@
+package org.powerbot.bot.rt4;
+
+import org.powerbot.script.TextPaintListener;
+import org.powerbot.script.rt4.ClientAccessor;
+import org.powerbot.script.rt4.ClientContext;
+
+import java.awt.*;
+
+import static org.powerbot.bot.DebugHelper.drawLine;
+
+public class TLoginState extends ClientAccessor implements TextPaintListener {
+	public TLoginState(final ClientContext ctx) {
+		super(ctx);
+	}
+
+	@Override
+	public int draw(int idx, final Graphics graphics) {
+		drawLine(graphics, idx++, "Login State: " + ctx.game.loginState());
+		return idx;
+	}
+}

--- a/src/main/java/org/powerbot/script/rt4/Constants.java
+++ b/src/main/java/org/powerbot/script/rt4/Constants.java
@@ -13,6 +13,10 @@ public final class Constants {
 	public static final int GAME_LOBBY = 25;
 	public static final int GAME_LOGGED = 30;
 
+	public static final int LOGIN_STATE_WELCOME = 0;
+	public static final int LOGIN_STATE_PVP_WARNING = 1;
+	public static final int LOGIN_STATE_ENTER_CREDENTIALS = 2;
+
 	public static final int BANK_WIDGET = 12;
 	public static final int BANK_ITEMS = 11;
 	public static final int BANK_SCROLLBAR = 12;

--- a/src/main/java/org/powerbot/script/rt4/Game.java
+++ b/src/main/java/org/powerbot/script/rt4/Game.java
@@ -191,6 +191,14 @@ public class Game extends ClientAccessor {
 	}
 
 	/**
+	 * @return The client's login state
+	 */
+	public int loginState() {
+		final Client c = ctx.client();
+		return c != null ? c.getLoginState() : -1;
+	}
+
+	/**
 	 * The current floor the client is at.
 	 *
 	 * @return the current floor the player is at, or -1 if the client has yet to be instantiated.


### PR DESCRIPTION
- adds support for Login State debugging in client view
- adds user setting for allowing/disallowing PVP worlds
- adds support for handling Login State 1: PVP World Warning Message
  - if user does not enable "Allow PVP Worlds" then script stops at this state

Fixes https://github.com/powerbot/RSBot-API/issues/2124