### PR TITLE
removes ID check from bank withdraw condition

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -370,9 +370,9 @@ public class Bank extends ItemQuery<Item> {
 				Condition.sleep();
 				ctx.input.sendln(String.valueOf(amount));
 			}
-			Condition.wait(() -> ctx.inventory.select().id(item.id()).count(true) != inventoryCount);
+			Condition.wait(() -> ctx.inventory.select().count(true) != inventoryCount);
 		}
-		return ctx.inventory.select().id(item.id()).count(true) - inventoryCount;
+		return ctx.inventory.select().count(true) - inventoryCount;
 	}
 
 	private boolean scrollToItem(final Item item) {


### PR DESCRIPTION
Not all noted items are id+1, so this removes the ID check entirely and instead waits for any change in the inventory. Since you can't withdraw multiple items simultaneously this should be fine. 

Fixes #2134 