### PR TITLE
Fix openedTabIndexOffset

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Game.java
+++ b/src/main/java/org/powerbot/script/rt4/Game.java
@@ -121,10 +121,11 @@ public class Game extends ClientAccessor {
 	}
 
 	private int openedTabIndexOffset(final Tab tab) {
-		if (bottomLineTabs()) {
+		if (resizable() && bottomLineTabs()) {
 			switch (tab) {
 			case LOGOUT:
 				return 1;
+			case ACCOUNT_MANAGEMENT:
 			case FRIENDS_LIST:
 			case IGNORED_LIST:
 			case CLAN_CHAT:


### PR DESCRIPTION
The option for bottomLineTabs does not affect fixed mode but was still being considered.