### PR TITLE
removed redundant code

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Equipment.java
+++ b/src/main/java/org/powerbot/script/rt4/Equipment.java
@@ -39,16 +39,11 @@ public class Equipment extends ItemQuery<Item> {
 	 */
 	public Item itemAt(final Slot slot) {
 		final int index = slot.getIndex();
-		final int[] data = ctx.players.local().appearance();
 		if (index < 0) {
 			return nil();
 		}
 		final Component c = ctx.widgets.widget(Constants.EQUIPMENT_WIDGET).component(slot.getComponentIndex()).component(1);
-		final boolean v = c.visible();
-		if ((index >= data.length || data[index] < 0) && !v) {
-			return nil();
-		}
-		return new Item(ctx, c, v ? c.itemId() : data[index], v ? c.itemStackSize() : 1);
+		return new Item(ctx, c, c.itemId(), c.itemStackSize());
 	}
 
 	/**


### PR DESCRIPTION
the required component data are loaded in regardless of the component being visible. With previous code ring and quiver items would return nil if you weren't looking at the component even thought they had valid data