### PR TITLE
reverse Redundant code

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Equipment.java
+++ b/src/main/java/org/powerbot/script/rt4/Equipment.java
@@ -39,13 +39,18 @@ public class Equipment extends ItemQuery<Item> {
 	 */
 	public Item itemAt(final Slot slot) {
 		final int index = slot.getIndex();
+		final int[] data = ctx.players.local().appearance();
 		if (index < 0) {
 			return nil();
 		}
 		final Component c = ctx.widgets.widget(Constants.EQUIPMENT_WIDGET).component(slot.getComponentIndex()).component(1);
+		final boolean v = c.visible();
+		if ((index >= data.length || data[index] < 0) && !v) {
+			return nil();
+		}
+		return new Item(ctx, c, v ? c.itemId() : data[index], v ? c.itemStackSize() : 1);
 		return new Item(ctx, c, c.itemId(), c.itemStackSize());
 	}
-
 	/**
 	 * {@inheritDoc}
 	 */


### PR DESCRIPTION
Equipment widget does not always load correctly -> leading to invalid query results when not on the equipment tab