### PR TITLE
Exposes tilePath on LocalPath.

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/LocalPath.java
+++ b/src/main/java/org/powerbot/script/rt4/LocalPath.java
@@ -21,6 +21,10 @@ public class LocalPath extends Path {
 		super(ctx);
 		this.destination = destination;
 	}
+	
+	public TilePath getTilePath() {
+		return this.tilePath;
+	}
 
 	static Graph getGraph(final ClientContext ctx) {
 		final Client client = ctx.client();


### PR DESCRIPTION
Safe to expose, means we can access the underlying tilepath for various use (eg drawing the projected route)