### PR TITLE
Allow npc and object interactions to rely on cache models

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Actor.java
+++ b/src/main/java/org/powerbot/script/rt4/Actor.java
@@ -14,10 +14,21 @@ import java.awt.*;
 public abstract class Actor extends Interactive implements InteractiveEntity, Nameable, Validatable , Modelable {
 
 	private Model model;
+	private final BoundingModel defaultBounds = new BoundingModel(ctx, -32, 32, -192, 0, -32, 32) {
+		@Override
+		public int x() {
+			return relative() >> 16;
+		}
+
+		@Override
+		public int z() {
+			return relative() & 0xffff;
+		}
+	};
 
 	Actor(final ClientContext ctx) {
 		super(ctx);
-		bounds(new int[]{-32, 32, -192, 0, -32, 32});
+		boundingModel.set(defaultBounds);
 	}
 
 	@Override
@@ -25,14 +36,12 @@ public abstract class Actor extends Interactive implements InteractiveEntity, Na
 		boundingModel.set(new BoundingModel(ctx, x1, x2, y1, y2, z1, z2) {
 			@Override
 			public int x() {
-				final int r = relative();
-				return r >> 16;
+				return relative() >> 16;
 			}
 
 			@Override
 			public int z() {
-				final int r = relative();
-				return r & 0xffff;
+				return relative() & 0xffff;
 			}
 		});
 	}
@@ -229,29 +238,47 @@ public abstract class Actor extends Interactive implements InteractiveEntity, Na
 
 	@Override
 	public Point nextPoint() {
+		// Non-default custom bounds take priority
 		final org.powerbot.bot.rt4.client.Actor actor = getActor();
 		final BoundingModel model2 = boundingModel.get();
-		if (actor != null && model2 != null) {
+		if (actor != null && model2 != null && !model2.equals(defaultBounds)) {
 			return model2.nextPoint();
 		}
-		return new Point(-1, -1);
+		final Model model = model();
+		if (model != null) {
+			return model.nextPoint(localX(), localY(), modelOrientation());
+		}
+		return model2 != null ? model2.nextPoint() : new Point(-1, -1);
 	}
 
 	@Override
 	public Point centerPoint() {
+		// Non-default custom bounds take priority
 		final org.powerbot.bot.rt4.client.Actor actor = getActor();
 		final BoundingModel model2 = boundingModel.get();
-		if (actor != null && model2 != null) {
+		if (actor != null && model2 != null && !model2.equals(defaultBounds)) {
 			return model2.centerPoint();
 		}
-		return new Point(-1, -1);
+		final Model model = model();
+		if (model != null) {
+			return model.centerPoint(localX(), localY(), modelOrientation());
+		}
+		return model2 != null ? model2.centerPoint() : new Point(-1, -1);
 	}
 
 	@Override
 	public boolean contains(final Point point) {
+		// Non-default custom bounds take priority
 		final org.powerbot.bot.rt4.client.Actor actor = getActor();
 		final BoundingModel model2 = boundingModel.get();
-		return actor != null && model2 != null && model2.contains(point);
+		if (actor != null && model2 != null && !model2.equals(defaultBounds)) {
+			return model2.contains(point);
+		}
+		final Model model = model();
+		if (model != null) {
+			return model.contains(point, localX(), localY(), modelOrientation());
+		}
+		return model2 != null && model2.contains(point);
 	}
 
 	@Override

--- a/src/main/java/org/powerbot/script/rt4/Actor.java
+++ b/src/main/java/org/powerbot/script/rt4/Actor.java
@@ -13,7 +13,6 @@ import java.awt.*;
  */
 public abstract class Actor extends Interactive implements InteractiveEntity, Nameable, Validatable , Modelable {
 
-	private Model model;
 	private final BoundingModel defaultBounds = new BoundingModel(ctx, -32, 32, -192, 0, -32, 32) {
 		@Override
 		public int x() {
@@ -238,10 +237,13 @@ public abstract class Actor extends Interactive implements InteractiveEntity, Na
 
 	@Override
 	public Point nextPoint() {
-		// Non-default custom bounds take priority
 		final org.powerbot.bot.rt4.client.Actor actor = getActor();
+		if (actor == null) {
+			return new Point(-1, -1);
+		}
+		// Non-default custom bounds take priority
 		final BoundingModel model2 = boundingModel.get();
-		if (actor != null && model2 != null && !model2.equals(defaultBounds)) {
+		if (model2 != null && !model2.equals(defaultBounds)) {
 			return model2.nextPoint();
 		}
 		final Model model = model();
@@ -253,10 +255,13 @@ public abstract class Actor extends Interactive implements InteractiveEntity, Na
 
 	@Override
 	public Point centerPoint() {
-		// Non-default custom bounds take priority
 		final org.powerbot.bot.rt4.client.Actor actor = getActor();
+		if (actor == null) {
+			return new Point(-1, -1);
+		}
+		// Non-default custom bounds take priority
 		final BoundingModel model2 = boundingModel.get();
-		if (actor != null && model2 != null && !model2.equals(defaultBounds)) {
+		if (model2 != null && !model2.equals(defaultBounds)) {
 			return model2.centerPoint();
 		}
 		final Model model = model();
@@ -268,10 +273,13 @@ public abstract class Actor extends Interactive implements InteractiveEntity, Na
 
 	@Override
 	public boolean contains(final Point point) {
-		// Non-default custom bounds take priority
 		final org.powerbot.bot.rt4.client.Actor actor = getActor();
+		if (actor == null) {
+			return false;
+		}
+		// Non-default custom bounds take priority
 		final BoundingModel model2 = boundingModel.get();
-		if (actor != null && model2 != null && !model2.equals(defaultBounds)) {
+		if (model2 != null && !model2.equals(defaultBounds)) {
 			return model2.contains(point);
 		}
 		final Model model = model();

--- a/src/main/java/org/powerbot/script/rt4/BoundingModel.java
+++ b/src/main/java/org/powerbot/script/rt4/BoundingModel.java
@@ -4,6 +4,7 @@ import org.powerbot.script.*;
 
 import java.awt.*;
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * BoundingModel
@@ -230,5 +231,22 @@ public abstract class BoundingModel extends ClientAccessor {
 			}
 		}
 		return Arrays.copyOf(model, faces);
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final BoundingModel that = (BoundingModel) o;
+		return Objects.equals(start, that.start) && Objects.equals(end, that.end);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(start, end);
 	}
 }

--- a/src/main/java/org/powerbot/script/rt4/GameObject.java
+++ b/src/main/java/org/powerbot/script/rt4/GameObject.java
@@ -26,12 +26,23 @@ public class GameObject extends Interactive implements Nameable, InteractiveEnti
 
 	private final BasicObject object;
 	private final Type type;
+	private final BoundingModel defaultBounds = new BoundingModel(ctx, -32, 32, -64, 0, -32, 32) {
+		@Override
+		public int x() {
+			return relative() >> 16;
+		}
 
-	GameObject(final ClientContext ctx, final BasicObject object, final Type type) {
+		@Override
+		public int z() {
+			return relative() & 0xffff;
+		}
+	};
+
+	GameObject(final ClientContext ctx, final BasicObject object, final Type type)  {
 		super(ctx);
 		this.object = object;
 		this.type = type;
-		bounds(-32, 32, -64, 0, -32, 32);
+		boundingModel.set(defaultBounds);
 	}
 
 	@Override
@@ -39,14 +50,12 @@ public class GameObject extends Interactive implements Nameable, InteractiveEnti
 		boundingModel.set(new BoundingModel(ctx, x1, x2, y1, y2, z1, z2) {
 			@Override
 			public int x() {
-				final int r = relative();
-				return r >> 16;
+				return relative() >> 16;
 			}
 
 			@Override
 			public int z() {
-				final int r = relative();
-				return r & 0xffff;
+				return relative() & 0xffff;
 			}
 		});
 	}
@@ -217,20 +226,44 @@ public class GameObject extends Interactive implements Nameable, InteractiveEnti
 
 	@Override
 	public Point centerPoint() {
-		final BoundingModel model = boundingModel.get();
-		return model != null ? model.centerPoint() : new Point(-1, -1);
+		// Non-default custom bounds take priority
+		final BoundingModel model2 = boundingModel.get();
+		if (model2 != null && !model2.equals(defaultBounds)) {
+			return model2.centerPoint();
+		}
+		final Model model = model();
+		if (model != null) {
+			return model.centerPoint(localX(), localY(), modelOrientation());
+		}
+		return model2 != null ? model2.centerPoint() : new Point(-1, -1);
 	}
 
 	@Override
 	public Point nextPoint() {
-		final BoundingModel model = boundingModel.get();
-		return model != null ? model.nextPoint() : new Point(-1, -1);
+		// Non-default custom bounds take priority
+		final BoundingModel model2 = boundingModel.get();
+		if (model2 != null && !model2.equals(defaultBounds)) {
+			return model2.nextPoint();
+		}
+		final Model model = model();
+		if (model != null) {
+			return model.nextPoint(localX(), localY(), modelOrientation());
+		}
+		return model2 != null ? model2.nextPoint() : new Point(-1, -1);
 	}
 
 	@Override
 	public boolean contains(final Point point) {
-		final BoundingModel model = boundingModel.get();
-		return model != null && model.contains(point);
+		// Non-default custom bounds take priority
+		final BoundingModel model2 = boundingModel.get();
+		if (model2 != null && !model2.equals(defaultBounds)) {
+			return model2.contains(point);
+		}
+		final Model model = model();
+		if (model != null) {
+			return model.contains(point, localX(), localY(), modelOrientation());
+		}
+		return model2 != null && model2.contains(point);
 	}
 
 	@Override

--- a/src/main/java/org/powerbot/script/rt4/Model.java
+++ b/src/main/java/org/powerbot/script/rt4/Model.java
@@ -1,5 +1,6 @@
 package org.powerbot.script.rt4;
 
+import org.powerbot.script.Random;
 import org.powerbot.script.Vector3;
 
 import java.awt.*;
@@ -67,7 +68,7 @@ public class Model {
 		final int[] vertY = verticesY();
 		final int[] vertZ = verticesZ();
 
-		final java.util.List<Polygon> polys = new ArrayList<>();
+		final List<Polygon> polys = new ArrayList<>();
 		final boolean resizable = ctx.game.resizable();
 		for (int i = 0; i < indX.length; i++) {
 			if (i >= indY.length && i >= indZ.length) {
@@ -94,12 +95,40 @@ public class Model {
 	 * @param localX the local x of the entity
 	 * @param localY the local y of the entity
 	 * @param orientation the orientation of the entity
-	 * @param graphics graphics object to draw with
+	 * @param g graphics object to draw with
 	 */
-	public void draw(final int localX, final int localY, final int orientation, final Graphics graphics) {
+	public void draw(final int localX, final int localY, final int orientation, final Graphics g) {
 		for (final Polygon polygon : polygons(localX, localY, orientation)) {
-			graphics.drawPolygon(polygon);
+			g.drawPolygon(polygon);
 		}
+	}
+
+	public Point nextPoint(final int localX, final int localY, final int orientation) {
+		final List<Polygon> polygons = polygons(localX, localY, orientation);
+		if (polygons.isEmpty()) {
+			return new Point(-1, -1);
+		}
+
+		// Select random triangle of model
+		final Polygon triangle = polygons.get(Random.nextInt(0, polygons.size() - 1));
+		final Point[] pts = {
+			new Point(triangle.xpoints[0], triangle.ypoints[0]),
+			new Point(triangle.xpoints[1], triangle.ypoints[1]),
+			new Point(triangle.xpoints[2], triangle.ypoints[2])
+		};
+
+		// Compute random point within triangle
+		final double r1 = Math.random(), r2 = Math.random();
+		final double sqrtR1 = Math.sqrt(r1);
+		final double sqrtR1R2 = sqrtR1 * r2;
+		final double x = (1 - sqrtR1) * pts[0].x + (sqrtR1 * (1 - r2)) * pts[1].x + sqrtR1R2 * pts[2].x;
+		final double y = (1 - sqrtR1) * pts[0].y + (sqrtR1 * (1 - r2)) * pts[1].y + sqrtR1R2 * pts[2].y;
+
+		return new Point((int) x, (int) y);
+	}
+
+	public boolean contains(final Point point, final int localX, final int localY, final int orientation) {
+		return polygons(localX, localY, orientation).stream().anyMatch(polygon -> polygon.contains(point));
 	}
 
 	private void setOrientation(final int orientation) {
@@ -108,7 +137,6 @@ public class Model {
 		for (int i = 0; i < originalVerticesX.length; ++i) {
 			verticesX[i] = originalVerticesX[i] * cos + originalVerticesZ[i] * sin >> 16;
 			verticesZ[i] = originalVerticesZ[i] * cos - originalVerticesX[i] * sin >> 16;
-
 		}
 	}
 

--- a/src/main/java/org/powerbot/script/rt4/Npc.java
+++ b/src/main/java/org/powerbot/script/rt4/Npc.java
@@ -122,11 +122,9 @@ public class Npc extends Actor implements Identifiable, Actionable {
 		return c != null ? c.colors2 : new short[]{};
 	}
 
-
 	@Override
 	public int[] modelIds() {
 		final CacheNpcConfig c = CacheNpcConfig.load(ctx.bot().getCacheWorker(), id());
-
 		return c != null ? c.modelIds : null;
 	}
 


### PR DESCRIPTION
The default cuboid bounding model will be used in case the cache model
fails to load. Additionally, if a custom bounding model is set by the
script writer, it will be used instead of the relevant cache model.

