### PR TITLE
Use model center point to check for NPC visibility

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Npc.java
+++ b/src/main/java/org/powerbot/script/rt4/Npc.java
@@ -38,6 +38,11 @@ public class Npc extends Actor implements Identifiable, Actionable {
 	}
 
 	@Override
+	public boolean inViewport() {
+		return ctx.game.inViewport(centerPoint());
+	}
+
+	@Override
 	public String name() {
 		final CacheNpcConfig c = CacheNpcConfig.load(ctx.bot().getCacheWorker(), id());
 		return c != null ? StringUtils.stripHtml(c.name) : "";


### PR DESCRIPTION
Without NPC model animations, nextPoint can cause inViewport to wrongly
return true. Using centerPoint instead remedies this.

![image](https://user-images.githubusercontent.com/1911217/85541858-c5aad900-b618-11ea-8183-18fffda32ae9.png)
